### PR TITLE
Development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+# ruby '2.5.1'
+ruby '2.6.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.2
+   2.1.0

--- a/app/assets/stylesheets/LabelIndexItem.css
+++ b/app/assets/stylesheets/LabelIndexItem.css
@@ -8,6 +8,7 @@
   display: flex;
   font-size: 14px;
   font-weight: 500;
+  cursor: pointer;
 }
 
 .label-index-item:hover {

--- a/app/assets/stylesheets/greeting.css
+++ b/app/assets/stylesheets/greeting.css
@@ -73,8 +73,10 @@
   padding-left: 25px;
   padding-right: 25px;
   width: 130px;
+  cursor: pointer;
 }
 
 .greeting-btn:focus {
   outline: 0;
+  cursor: pointer;
 }

--- a/frontend/components/NoteFormCreate.jsx
+++ b/frontend/components/NoteFormCreate.jsx
@@ -30,7 +30,7 @@ class NoteFormCreate extends React.Component {
   }
 
   togglePanel(e) {
-    this.setState({ open: !this.state.open })
+    this.setState({ open: true })
     const textArea = document.querySelector('.note-create-body');
     autosize(textArea);
   }

--- a/frontend/store/store.js
+++ b/frontend/store/store.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import rootReducer from '../reducers/root_reducer';
 
 const configureStore = (preloadedState = {}) => {
-  return createStore(rootReducer, preloadedState, applyMiddleware(thunk, logger));
+  return createStore(rootReducer, preloadedState, applyMiddleware(thunk));
 }
 
 export default configureStore;


### PR DESCRIPTION
The note form would close, after open, on click of the text area.  Now the only way to close is by clicking the "close" word.